### PR TITLE
Search in sysconfdir if there is no config in $XDG_CONFIG_DIRS

### DIFF
--- a/surfraw.IN
+++ b/surfraw.IN
@@ -36,10 +36,14 @@ find_global_conf () {
 		break
 	    fi
 	done
-    elif test -r "@sysconfdir@/xdg/surfraw/$base"; then # XDG default
-	conf="@sysconfdir@/xdg/surfraw/$base"
-    elif test -r "@sysconfdir@/surfraw.$base"; then # old surfraw default
-	conf="@sysconfdir@/surfraw.$base"
+    fi
+
+    if test -n "$conf"; then
+        if test -r "@sysconfdir@/xdg/surfraw/$base"; then # XDG default
+	    conf="@sysconfdir@/xdg/surfraw/$base"
+        elif test -r "@sysconfdir@/surfraw.$base"; then # old surfraw default
+	    conf="@sysconfdir@/surfraw.$base"
+        fi
     fi
     echo "$conf"
 }


### PR DESCRIPTION
Currently the search for the global configuration file returns nothing if $XDG_CONFIG_DIRS is set and there is no surfraw configuration file. This is confusing as the error message says

```"couldn't find global config in @sysconfdir@/xdg/surfraw/conf or \$XDG_CONFIG_DIRS"```

Indicating it searched for the configuration in $XDG_CONFIG_DIRS **and** sysconfdir. With this patch it will continue to search in sysconfdir if there was no configuration file in $XDG_CONFIG_DIRS.